### PR TITLE
If thumbnail is being updated, use object from islandora_object_load() instead

### DIFF
--- a/includes/tn_upload.form.inc
+++ b/includes/tn_upload.form.inc
@@ -59,7 +59,15 @@ function islandora_entities_get_tn_upload_form($form_state = NULL) {
  *   The drupal form state.
  */
 function islandora_entities_tn_upload_form_submit(array $form, array &$form_state) {
-  $object = $form_state['islandora']['objects'][0];
+  // Is this a thumbnail update?
+  $factory_object = islandora_object_load($form_state['islandora']['objects'][0]->id);
+  if (is_object(islandora_object_load($factory_object))) {
+    $object = $factory_object;
+  }
+  else {
+    $object = $form_state['islandora']['objects'][0];
+  }
+
   $tn_file = file_load($form_state['values']['file']);
   if (isset($tn_file->uri)) {
     $tn_path = drupal_realpath($tn_file->uri);


### PR DESCRIPTION
Attempting to change/re-upload an entity thumbnail from 7.x HEAD results in an error:

![screen shot 2014-10-08 at 3 35 48 pm](https://cloud.githubusercontent.com/assets/244894/4564756/07e9fd4e-4f1a-11e4-868e-fb638712a573.png)

`RepositoryException: Conflict in RepositoryConnection->parseFedoraExceptions() (line 229 of /var/www/drupal/sites/all/libraries/tuque/RepositoryConnection.php).`

Fedora error log shows:

https://gist.github.com/JacobSanford/72a401e5bbd8f334a9e4

This seemed very similar to that mentioned:
https://github.com/ruebot/islandora_checksum/issues/5
and solved:
https://github.com/Islandora/islandora_xml_forms/commit/40860180622b6e0f474604498c94f7f952b6e0c4

I modeled the fix after that.
