### PR TITLE
Correct error in datastream edit hook function naming

### DIFF
--- a/islandora_entities.module
+++ b/islandora_entities.module
@@ -383,7 +383,7 @@ function islandora_entities_islandora_xml_form_builder_forms() {
  *
  * Hacks an autocomplete path from this solution pack into the scholar forms.
  */
-function islandora_entities_form_xml_form_builder_edit_datastream_form_alter(&$form, &$form_state, $form_id) {
+function islandora_entities_form_xml_form_builder_datastream_form_alter(&$form, &$form_state, $form_id) {
   if (module_exists('islandora_scholar')) {
     module_load_include('inc', 'islandora_entities', 'includes/utilities');
     if (isset($form_state['association']['id'])) {


### PR DESCRIPTION
7.x HEAD has a hook referencing an incorrect form ID for editing datastreams. As a result, the autocomplete elements are not injected on 'editing' scholar ctypes, only on ingest.
