### PR TITLE
fix for scholars with multiple departments

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -61,6 +61,7 @@ function islandora_entities_preprocess_islandora_person(array &$variables) {
       }
       if (count($colleages) > 0) {
         foreach ($colleages as $dept => $members) {
+          $links = array();
           foreach ($members as $pid => $scholar) {
             $links[] = l($scholar, "islandora/object/$pid/view");
           }


### PR DESCRIPTION
When viewing a scholar with multiple departments the links array was not being reset between departments. This caused the later department lists to contain scholars from the earlier lists as well as its own.
