### PR TITLE
handling menu path more drupal-y

### DIFF
--- a/islandora_entities.module
+++ b/islandora_entities.module
@@ -628,7 +628,7 @@ function islandora_entities_preprocess_html(&$variables) {
   $object = menu_get_object('islandora_object', 2);
   // Making sure the router position is there, and that an object gets loaded,
   // and that it has the right content model, in that order.
-  if (!is_null($object) && $object !== FALSE && in_array('islandora:entityCModel', $object->models)) {
+  if (is_object($object) && in_array('islandora:entityCModel', $object->models)) {
     $variables['classes_array'][] = "islandora-entity";
   }
 }

--- a/islandora_entities.module
+++ b/islandora_entities.module
@@ -625,13 +625,10 @@ function islandora_entities_citation_access($object, $type) {
  * Implements hook_preprocess_html().
  */
 function islandora_entities_preprocess_html(&$variables) {
-  if (isset($_GET['q'])) {
-    $q_parts = explode('/', $_GET['q']);
-    if ($q_parts[0] == 'islandora' && $q_parts[1] == 'object') {
-      $object = islandora_object_load($q_parts[2]);
-      if ($object && in_array('islandora:entityCModel', $object->models)) {
-        $variables['classes_array'][] = "islandora-entity";
-      }
-    }
+  $object = menu_get_object('islandora_object', 2);
+  // Making sure the router position is there, and that an object gets loaded,
+  // and that it has the right content model, in that order.
+  if (!is_null($object) && $object !== FALSE && in_array('islandora:entityCModel', $object->models)) {
+    $variables['classes_array'][] = "islandora-entity";
   }
 }

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -147,6 +147,7 @@ function islandora_entities_get_dept_members($dept, $pid) {
  * Implements hook_preprocess().
  */
 function islandora_entities_preprocess_islandora_dept(array &$variables) {
+  dd($variables);
   module_load_include('inc', 'islandora', 'includes/metadata');
   $object = $variables['object'];
   $variables['metadata'] = islandora_retrieve_metadata_markup($object, TRUE);

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -147,7 +147,6 @@ function islandora_entities_get_dept_members($dept, $pid) {
  * Implements hook_preprocess().
  */
 function islandora_entities_preprocess_islandora_dept(array &$variables) {
-  dd($variables);
   module_load_include('inc', 'islandora', 'includes/metadata');
   $object = $variables['object'];
   $variables['metadata'] = islandora_retrieve_metadata_markup($object, TRUE);


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1538
# What does this Pull Request do?

Bit of an improvement to the way that the islandora-entity class is added to the body tag of entities objects. Hopefully this should represent a more Drupal-y, simple method that makes use of cached stuff in Drupal a bit better.
# How should this be tested?

Entity object pages should be checked to see that the islandora-entity class still shows up on the body tag. No other pages should have that class. 
# Background context:

This came out of an attempt to customize some menu pathing that wound up exposing the fact that the entities html_preprocess hook was assuming the existence of menu path parts. This should just close up that hole.
# Additional Information

It should be noted that hook_html_preprocess seems to be a really heavy-handed way of accomplishing what this hook implementation is trying to do (i.e., adding a class to the body so that injected CSS triggers on entity objects). It may be worth, sometime down the line, refactoring some of this so that hook_html_preprocess doesn't have to be called, and so that we can implement the same functionality in a more Drupal Theme-centric way that passes around objects and theme variables, so that customization modules can load CSS conditionally in those cases.

I wasn't able to find any public instances of CSS requiring this class. In the case of a refactor, we might ask around who is using this and see if we can convince them to move over to a different thing. For now, this pull request should do.

**Tagging:** @Islandora/7-x-1-x-committers and @whikloj as the component manager.

---

QA Dan
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
