### PR TITLE
ISLANDORA-1484: Fixes typos in xml forms to replace 'Intentity' with …

### DIFF
--- a/xml/organization_eac_cpf_read_only.xml
+++ b/xml/organization_eac_cpf_read_only.xml
@@ -54,7 +54,7 @@
               <type>fieldset</type>
               <access>TRUE</access>
               <required>FALSE</required>
-              <title>Intentity information</title>
+              <title>Identity information</title>
               <tree>TRUE</tree>
             </properties>
             <children>
@@ -63,7 +63,7 @@
                   <type>markup</type>
                   <access>TRUE</access>
                   <required>FALSE</required>
-                  <title>Intentity information</title>
+                  <title>Identity information</title>
                   <tree>TRUE</tree>
                   <actions>
                     <create>

--- a/xml/organization_eaccpf_form.xml
+++ b/xml/organization_eaccpf_form.xml
@@ -54,7 +54,7 @@
               <type>fieldset</type>
               <access>TRUE</access>
               <required>FALSE</required>
-              <title>Intentity information</title>
+              <title>Identity information</title>
               <tree>TRUE</tree>
             </properties>
             <children>
@@ -63,7 +63,7 @@
                   <type>markup</type>
                   <access>TRUE</access>
                   <required>FALSE</required>
-                  <title>Intentity information</title>
+                  <title>Identity information</title>
                   <tree>TRUE</tree>
                   <actions>
                     <create>

--- a/xml/person_eac_cpf_read_only.xml
+++ b/xml/person_eac_cpf_read_only.xml
@@ -63,7 +63,7 @@
                   <type>markup</type>
                   <access>TRUE</access>
                   <required>FALSE</required>
-                  <title>Intentity information</title>
+                  <title>Identity information</title>
                   <tree>TRUE</tree>
                   <actions>
                     <create>

--- a/xml/person_eaccpf_form.xml
+++ b/xml/person_eaccpf_form.xml
@@ -63,7 +63,7 @@
                   <type>markup</type>
                   <access>TRUE</access>
                   <required>FALSE</required>
-                  <title>Intentity information</title>
+                  <title>Identity information</title>
                   <tree>TRUE</tree>
                   <actions>
                     <create>

--- a/xml/place_eac-cpf_read_only.xml
+++ b/xml/place_eac-cpf_read_only.xml
@@ -54,7 +54,7 @@
               <type>fieldset</type>
               <access>TRUE</access>
               <required>FALSE</required>
-              <title>Intentity information</title>
+              <title>Indentity information</title>
               <tree>TRUE</tree>
             </properties>
             <children>
@@ -63,7 +63,7 @@
                   <type>markup</type>
                   <access>TRUE</access>
                   <required>FALSE</required>
-                  <title>Intentity information</title>
+                  <title>Identity information</title>
                   <tree>TRUE</tree>
                   <actions>
                     <create>

--- a/xml/place_eaccpf_form.xml
+++ b/xml/place_eaccpf_form.xml
@@ -54,7 +54,7 @@
               <type>fieldset</type>
               <access>TRUE</access>
               <required>FALSE</required>
-              <title>Intentity information</title>
+              <title>Identity information</title>
               <tree>TRUE</tree>
             </properties>
             <children>
@@ -63,7 +63,7 @@
                   <type>markup</type>
                   <access>TRUE</access>
                   <required>FALSE</required>
-                  <title>Intentity information</title>
+                  <title>Identity information</title>
                   <tree>TRUE</tree>
                   <actions>
                     <create>


### PR DESCRIPTION
**ISLANDORA-1484**: https://jira.duraspace.org/browse/ISLANDORA-1484
# What does this Pull Request do?

Replaces instances of 'Intentity' with 'Identity' in various XML forms:
<img width="1022" alt="screen shot 2016-03-24 at 2 58 26 pm" src="https://cloud.githubusercontent.com/assets/3837461/14028822/0543813c-f1d5-11e5-8af8-ffdfeb44d10c.png">
# What's new?

Simple typo changes.
# Additional Notes:

This is based on the assumption that "Intentity" was a misspelling of "Identity" and NOT "Entity" (as proposed by Zach Vowell in the JIRA ticket). I think this because the sections with `<title>Intentity information</title>` had `<path>eac-cpf:identity</path>`.
# Interested parties

@Islandora/7-x-1-x-committers
@zvowell
@manez 
