### PR TITLE
Fix islandora_solr_search module name

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -34,7 +34,7 @@ function islandora_entities_add_entity_content_model(AbstractObject $fedora_obje
  *   IslandoraSolrQueryProcessor->islandoraSolrResult
  */
 function islandora_entities_solr_search_entities($content_model, $entities_query) {
-  module_load_include('inc', 'islandora_solr_search', 'includes/utilities');
+  module_load_include('inc', 'islandora_solr', 'includes/utilities');
   $results = array();
 
   $content_model_field = variable_get(


### PR DESCRIPTION
**JIRA Ticket**:
- [Incorrect module_load_include calls for files in islandora_solr module](https://jira.duraspace.org/browse/ISLANDORA-1770)
- [Drupal 7.5 missing module warning (related)](https://jira.duraspace.org/browse/ISLANDORA-1757)
- [How to fix "The following module is missing from the file system..." warning messages](https://www.drupal.org/node/2487215)
# What does this Pull Request do?

Upgrading to Drupal 7.5 adds a php warning if there are issues locating modules or themes in the file system.

`User warning: The following module is missing from the file system: islandora_solr_search. In order to fix this, put the module back in its original location. For more information, see the documentation page. in _drupal_trigger_error_with_delayed_logging() (line 1128 of /var/www/html/drupal7/includes/bootstrap.inc).`

Grep identified two modules which had incorrect module name for module_load_include():
- islandora_solr_metadata
- islandora_solution_pack_entities

This PR corrects the module name.
