### PR TITLE
ISLANDORA-1883 Add sorting for citations and theses on scholar profiles

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -136,5 +136,16 @@ function islandora_entities_settings($form, &$form_state) {
     '#required' => TRUE,
   );
 
+  $form['islandora_entities_query_sort'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Solr field to sort citations and theses by.'),
+    '#default_value' => variable_get(
+      'islandora_entities_query_sort',
+      ''
+    ),
+    '#description' => t('Used to sort citations and theses on scholar profile pages. Should contain the solr field followed by a space and either "asc" or "desc". For example, "mods_originInfo_keyDate_yes_dateIssued_dt asc" will sort on the dateIssued field in ascending order.'),
+    '#required' => FALSE,
+  );
+
   return system_settings_form($form);
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -134,6 +134,7 @@ function islandora_entities_get_related($identifier, $title, $type) {
   $query = "+mods_name_personal_displayForm_mt:\"($identifier)\"  {$base_query[$type]}";
   $params = array(
     'fl' => 'dc.title, PID',
+    'sort' => variable_get('islandora_entities_query_sort', ''),
   );
 
   $url = parse_url(variable_get('islandora_solr_url', 'localhost:8080/solr'));
@@ -209,6 +210,7 @@ function islandora_entities_get_related_pids($identifier, $title, $type) {
 
   $params = array(
     'fl' => 'dc.title, mods_name_personal_displayForm_mt, PID',
+    'sort' => variable_get('islandora_entities_query_sort', ''),
   );
 
   $url = parse_url(variable_get('islandora_solr_url', 'localhost:8080/solr'));

--- a/islandora_entities.install
+++ b/islandora_entities.install
@@ -31,6 +31,7 @@ function islandora_entities_uninstall() {
     'islandora_entities_department_solr_field',
     'islandora_entities_disambiguated_solr_field',
     'islandora_entities_last_name_solr_field',
+    'islandora_entities_query_sort',
   );
   foreach ($drupal_variables as $drupal_variable) {
     variable_del($drupal_variable);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1883

# What does this Pull Request do?

Adds a variable to the admin form for the entities solution pack. This variable allows admin to specify a sort field to the Solr query which is applied to recent citations on the view tab, as well as the citations and theses tabs in a scholar profile.


# What's new?

The Solr query mentioned above will now have a sort parameter which can be set by site admin.


# How should this be tested?

1. Go to admin/islandora/solution_pack_config/entities and add something to the sort field. Something like "mods_originInfo_keyDate_yes_dateIssued_dt asc" or "mods_titleInfo_title_t desc". 
2. Go to a scholar profile and look at the view, citations, and theses tabs to see sorted results.


# Additional Notes:

By default the sort param is left blank which should result in the same sort order as before the sort field was added

This new field should be added to the next iteration of the documentation.


# Interested parties

@Islandora/7-x-1-x-committers
