### PR TITLE
ISLANDORA-1574 fix theses tab under scholar profile not appearing

### DIFF
--- a/islandora_entities.module
+++ b/islandora_entities.module
@@ -107,7 +107,7 @@ function islandora_entities_menu() {
       'page callback' => 'drupal_get_form',
       'page arguments' => array('islandora_entities_citation_form', 2, 'theses'),
       'access callback' => 'islandora_entities_citation_access',
-      'access arguments' => array(2, "citations"),
+      'access arguments' => array(2, "theses"),
       'file' => 'includes/citation_tab.inc',
       'weight' => 2,
     ),


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1574


# What does this Pull Request do?

Fixes a bug where the 'Theses' tab in the scholar profile was not showing when it should. The 'Theses' tab was being shown on the condition that the scholar was linked to one or more citations instead of theses.

# What's new?

The 'Theses' tab now is shown on the condition that the scholar is linked to a thesis.

# How should this be tested?

Add 3 scholars: 
1. One who is linked to both citations and theses
2. One who is only linked to citations
3. One who is only linked to theses

Go to each of their scholar profiles and see which tabs are available.

Before this update, the first two scholars will have 'Citations' and "Theses' tabs available, while the third will have neither. After the update they will have the correct tabs available.

# Additional Notes:

# Interested parties
@Islandora/7-x-1-x-committers
