### PR TITLE
ISLANDORA-1904 Update DC datastream via hook_xml_form_builder_get_transforms()

### DIFF
--- a/islandora_entities.module
+++ b/islandora_entities.module
@@ -543,9 +543,9 @@ function islandora_entities_islandora_organizationCModel_islandora_object_ingest
 }
 
 /**
- * Implements hook_islandora_xml_form_builder_get_transforms().
+ * Implements hook_xml_form_builder_get_transforms().
  */
-function islandora_entities_islandora_xml_form_builder_get_transforms() {
+function islandora_entities_xml_form_builder_get_transforms() {
   $module_path = drupal_get_path('module', 'islandora_entities');
   return array(
     'eaccpf_to_dc.xsl' => "$module_path/xml/eaccpf_to_dc.xsl",


### PR DESCRIPTION

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1904
* Github issue #108 

# What does this Pull Request do?

Fix failure to update DC datastream by using correct hook: hook_xml_form_builder_get_transforms() instead of hook_islandora_xml_form_builder_get_transforms(). 

# What's new?
Altered islandora_entities.module to fix hook instance. DC datastream is now updated when EAC-CPF or MADS is updated.

# How should this be tested?

* To recreate issue:
Create Person or Place entity. Edit entity and save. Notice EAC-CPF or MADS datastream revision increments but DC revision doesn't not.
* Test that the Pull Request does what is intended.
Apply patch to use correct hook: hook_xml_form_builder_get_transforms(). Edit entity and save. Notice that now DC datastream is updated.

# Additional Notes:
I suspect there are other changes to be made elsewhere in the Islandora Entities code to keep pace with renamed hooks.

# Interested parties
@Islandora/7-x-1-x-committers
