### PR TITLE
Make entities use IslandoraSolrQueryProcessor

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -136,5 +136,16 @@ function islandora_entities_settings($form, &$form_state) {
     '#required' => TRUE,
   );
 
+  $form['islandora_entities_query_sort'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Solr field to sort citations and theses by.'),
+    '#default_value' => variable_get(
+      'islandora_entities_query_sort',
+      ''
+    ),
+    '#description' => t('Used to sort citations and theses on scholar profile pages. Should contain the solr field followed by a space and either "asc" or "desc". For example, "mods_originInfo_keyDate_yes_dateIssued_dt asc" will sort on the dateIssued field in ascending order.'),
+    '#required' => FALSE,
+  );
+
   return system_settings_form($form);
 }

--- a/includes/callbacks.inc
+++ b/includes/callbacks.inc
@@ -60,6 +60,7 @@ function islandora_entities_query_entities_callback($type) {
  *   array of all candidates
  */
 function islandora_entities_autocomplete($type) {
+  module_load_include('inc', 'islandora_solr', 'includes/query_processor');
 
   $mappings = array(
     'scholar' => array(
@@ -90,18 +91,16 @@ function islandora_entities_autocomplete($type) {
     'fl' => array($mappings[$type]['title'], 'PID'),
   );
   $query = "$qualifier AND " . 'RELS_EXT_hasModel_uri_mt:"' . $mappings[$type]['cmodel'] . '"';
-  $url = parse_url(variable_get('islandora_solr_url', 'localhost:8080/solr'));
-  $solr = new Apache_Solr_Service($url['host'], $url['port'], $url['path'] . '/');
-  $solr->setCreateDocuments(FALSE);
+  $qp = new IslandoraSolrQueryProcessor();
+  $qp->buildAndExecuteQuery($query, $params);
   try {
-    $results = $solr->search($query, 0, 1000, $params);
-    $json = json_decode($results->getRawResponse(), TRUE);
+    $results = $qp->islandoraSolrResult['response']['docs'];
   }
   catch (Exception $e) {
     watchdog_exception('Islandora Entities', $e, 'Got an exception while searching entities for callback.', array(), WATCHDOG_ERROR);
   }
   $list = array();
-  foreach ($json['response']['docs'] as $choice) {
+  foreach ($results as $choice) {
     if (isset($choice[$mappings[$type]['title']])) {
       $list[$choice[$mappings[$type]['title']][0]] = $choice[$mappings[$type]['title']][0];
     }

--- a/includes/callbacks.inc
+++ b/includes/callbacks.inc
@@ -94,15 +94,15 @@ function islandora_entities_autocomplete($type) {
   $qp = new IslandoraSolrQueryProcessor();
   $qp->buildAndExecuteQuery($query, $params);
   try {
-    $results = $qp->islandoraSolrResult['response']['docs'];
+    $results = $qp->islandoraSolrResult['response']['objects'];
   }
   catch (Exception $e) {
     watchdog_exception('Islandora Entities', $e, 'Got an exception while searching entities for callback.', array(), WATCHDOG_ERROR);
   }
   $list = array();
   foreach ($results as $choice) {
-    if (isset($choice[$mappings[$type]['title']])) {
-      $list[$choice[$mappings[$type]['title']][0]] = $choice[$mappings[$type]['title']][0];
+    if (isset($choice['solr_doc'][$mappings[$type]['title']])) {
+      $list[$choice['solr_doc'][$mappings[$type]['title']][0]] = $choice['solr_doc'][$mappings[$type]['title']][0];
     }
   }
 

--- a/includes/entities_rss.inc
+++ b/includes/entities_rss.inc
@@ -73,17 +73,17 @@ function islandora_entities_get_rss_related($identifier, $type) {
   $qp = new IslandoraSolrQueryProcessor();
   $qp->buildAndExecuteQuery($query, $params);
   try {
-    $results = $qp->islandoraSolrResult['response']['docs'];
+    $results = $qp->islandoraSolrResult['response']['objects'];
   }
   catch (Exception $e) {
     watchdog_exception('Islandora Entities', $e, 'Got an exception while searching an entities citations.', array(), WATCHDOG_ERROR);
   }
   $return = "";
   foreach ($results as $choice) {
-    if (isset($choice['dc.title'])) {
-      $description = isset($choice['dc.description'][0]) ? $choice['dc.description'][0] : "No Description";
+    if (isset($choice['solr_doc']['dc.title'])) {
+      $description = isset($choice['solr_doc']['dc.description'][0]) ? $choice['solr_doc']['dc.description'][0] : "No Description";
       $link = l(t("View"), 'islandora/object/' . $choice['PID']);
-      $return .= format_rss_item($choice['dc.title'][0], "$base_url/islandora/object/" . $choice['PID'], $description);
+      $return .= format_rss_item($choice['solr_doc']['dc.title'][0], "$base_url/islandora/object/" . $choice['PID'], $description);
     }
   }
   return $return;

--- a/includes/entities_rss.inc
+++ b/includes/entities_rss.inc
@@ -58,6 +58,7 @@ function islandora_entities_rss($pid) {
  *   The string formatted RSS items.
  */
 function islandora_entities_get_rss_related($identifier, $type) {
+  module_load_include('inc', 'islandora_solr', 'includes/query_processor');
   global $base_url;
   $mappings = array(
     'citations' => 'ir:citationCModel',
@@ -69,18 +70,16 @@ function islandora_entities_get_rss_related($identifier, $type) {
   );
   $query = "+RELS_EXT_hasModel_uri_mt:\"$content_model\" +mods_name_personal_displayForm_mt:\"($identifier)\"";
 
-  $url = parse_url(variable_get('islandora_solr_url', 'localhost:8080/solr'));
-  $solr = new Apache_Solr_Service($url['host'], $url['port'], $url['path'] . '/');
-  $solr->setCreateDocuments(FALSE);
+  $qp = new IslandoraSolrQueryProcessor();
+  $qp->buildAndExecuteQuery($query, $params);
   try {
-    $results = $solr->search($query, 0, 20, $params);
-    $json = json_decode($results->getRawResponse(), TRUE);
+    $results = $qp->islandoraSolrResult['response']['docs'];
   }
   catch (Exception $e) {
     watchdog_exception('Islandora Entities', $e, 'Got an exception while searching an entities citations.', array(), WATCHDOG_ERROR);
   }
   $return = "";
-  foreach ($json['response']['docs'] as $choice) {
+  foreach ($results as $choice) {
     if (isset($choice['dc.title'])) {
       $description = isset($choice['dc.description'][0]) ? $choice['dc.description'][0] : "No Description";
       $link = l(t("View"), 'islandora/object/' . $choice['PID']);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -140,15 +140,15 @@ function islandora_entities_get_related($identifier, $title, $type) {
   $qp = new IslandoraSolrQueryProcessor();
   $qp->buildAndExecuteQuery($query, $params);
   try {
-    $results = $qp->islandoraSolrResult['response']['docs'];
+    $results = $qp->islandoraSolrResult['response']['objects'];
   }
   catch (Exception $e) {
     watchdog_exception('Islandora Entities', $e, 'Got an exception while searching entities for callback.', array(), WATCHDOG_ERROR);
   }
   $links = array();
   foreach ($results as $choice) {
-    if (isset($choice['dc.title'])) {
-      $links[] = l($choice['dc.title'][0], 'islandora/object/' . $choice['PID']);
+    if (isset($choice['solr_doc']['dc.title'])) {
+      $links[] = l($choice['solr_doc']['dc.title'][0], 'islandora/object/' . $choice['PID']);
     }
   }
   if (count($links) > 0) {
@@ -214,7 +214,7 @@ function islandora_entities_get_related_pids($identifier, $title, $type) {
   $qp = new IslandoraSolrQueryProcessor();
   $qp->buildAndExecuteQuery($query, $params);
   try {
-    $search_results = $qp->islandoraSolrResult['response']['docs'];
+    $search_results = $qp->islandoraSolrResult['response']['objects'];
   }
   catch (Exception $e) {
     watchdog_exception('Islandora Entities', $e, 'Got an exception while searching entities for callback.', array(), WATCHDOG_ERROR);
@@ -223,8 +223,8 @@ function islandora_entities_get_related_pids($identifier, $title, $type) {
   foreach ($search_results as $choice) {
     $results[$choice['PID']] = array(
       'PID' => $choice['PID'],
-      'title' => $choice['dc.title'],
-      'authors' => $choice['mods_name_personal_displayForm_mt'],
+      'title' => $choice['solr_doc']['dc.title'],
+      'authors' => $choice['solr_doc']['mods_name_personal_displayForm_mt'],
     );
   }
   return $results;

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -123,6 +123,7 @@ function islandora_entities_create_citation_tab(AbstractObject $object) {
  *   Array of links pointing to citations
  */
 function islandora_entities_get_related($identifier, $title, $type) {
+  module_load_include('inc', 'islandora_solr', 'includes/query_processor');
   $base_query = array(
     'citations' => variable_get(
       'islandora_entities_citation_base_query',
@@ -136,18 +137,16 @@ function islandora_entities_get_related($identifier, $title, $type) {
     'fl' => 'dc.title, PID',
   );
 
-  $url = parse_url(variable_get('islandora_solr_url', 'localhost:8080/solr'));
-  $solr = new Apache_Solr_Service($url['host'], $url['port'], $url['path'] . '/');
-  $solr->setCreateDocuments(FALSE);
+  $qp = new IslandoraSolrQueryProcessor();
+  $qp->buildAndExecuteQuery($query, $params);
   try {
-    $results = $solr->search($query, 0, 20, $params);
-    $json = json_decode($results->getRawResponse(), TRUE);
+    $results = $qp->islandoraSolrResult['response']['docs'];
   }
   catch (Exception $e) {
     watchdog_exception('Islandora Entities', $e, 'Got an exception while searching entities for callback.', array(), WATCHDOG_ERROR);
   }
   $links = array();
-  foreach ($json['response']['docs'] as $choice) {
+  foreach ($results as $choice) {
     if (isset($choice['dc.title'])) {
       $links[] = l($choice['dc.title'][0], 'islandora/object/' . $choice['PID']);
     }
@@ -197,6 +196,7 @@ function islandora_entities_create_theses_tab(AbstractObject $object) {
  *   Array of links pointing to citations
  */
 function islandora_entities_get_related_pids($identifier, $title, $type) {
+  module_load_include('inc', 'islandora_solr', 'includes/query_processor');
   $base_query = array(
     'citations' => variable_get(
       'islandora_entities_citation_base_query',
@@ -211,18 +211,16 @@ function islandora_entities_get_related_pids($identifier, $title, $type) {
     'fl' => 'dc.title, mods_name_personal_displayForm_mt, PID',
   );
 
-  $url = parse_url(variable_get('islandora_solr_url', 'localhost:8080/solr'));
-  $solr = new Apache_Solr_Service($url['host'], $url['port'], $url['path'] . '/');
-  $solr->setCreateDocuments(FALSE);
+  $qp = new IslandoraSolrQueryProcessor();
+  $qp->buildAndExecuteQuery($query, $params);
   try {
-    $search_results = $solr->search($query, 0, 20, $params);
-    $json = json_decode($search_results->getRawResponse(), TRUE);
+    $search_results = $qp->islandoraSolrResult['response']['docs'];
   }
   catch (Exception $e) {
     watchdog_exception('Islandora Entities', $e, 'Got an exception while searching entities for callback.', array(), WATCHDOG_ERROR);
   }
   $results = array();
-  foreach ($json['response']['docs'] as $choice) {
+  foreach ($search_results as $choice) {
     $results[$choice['PID']] = array(
       'PID' => $choice['PID'],
       'title' => $choice['dc.title'],

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -106,7 +106,7 @@ function islandora_entities_create_citation_tab(AbstractObject $object) {
     $simplexml = simplexml_load_string($mads);
     $identifiers = $simplexml->identifier;
     foreach ($identifiers as $identifier) {
-      if ($identifier['type'] == 'u1') {
+      if ($identifier['type'] == 'u1' && (string) $identifier) {
         return islandora_entities_get_related((string) $identifier, (string) $simplexml->authority->titleInfo->title, 'citations');
       }
     }
@@ -132,11 +132,13 @@ function islandora_entities_get_related($identifier, $title, $type) {
       'islandora_entities_thesis_base_query',
       '+RELS_EXT_hasModel_uri_mt:"ir:thesisCModel"'),
   );
-  $query = "+mods_name_personal_displayForm_mt:\"($identifier)\"  {$base_query[$type]}";
+  $query = "+mods_name_personal_displayForm_mt:\"($identifier)\" AND {$base_query[$type]}";
   $params = array(
     'fl' => 'dc.title, PID',
-    'sort' => variable_get('islandora_entities_query_sort', ''),
   );
+  if (strlen(variable_get('islandora_entities_query_sort', '')) > 0) {
+    $params['sort'] = variable_get('islandora_entities_query_sort', '');
+  }
 
   $qp = new IslandoraSolrQueryProcessor();
   $qp->buildAndExecuteQuery($query, $params);
@@ -145,11 +147,14 @@ function islandora_entities_get_related($identifier, $title, $type) {
   }
   catch (Exception $e) {
     watchdog_exception('Islandora Entities', $e, 'Got an exception while searching entities for callback.', array(), WATCHDOG_ERROR);
+    $results = array();
   }
   $links = array();
-  foreach ($results as $choice) {
-    if (isset($choice['solr_doc']['dc.title'])) {
-      $links[] = l($choice['solr_doc']['dc.title'][0], 'islandora/object/' . $choice['PID']);
+  if ($results) {
+    foreach ($results as $choice) {
+      if (isset($choice['solr_doc']['dc.title'])) {
+        $links[] = l($choice['solr_doc']['dc.title'][0], 'islandora/object/' . $choice['PID']);
+      }
     }
   }
   if (count($links) > 0) {
@@ -206,12 +211,14 @@ function islandora_entities_get_related_pids($identifier, $title, $type) {
       'islandora_entities_thesis_base_query',
       '+RELS_EXT_hasModel_uri_mt:"ir:thesisCModel"'),
   );
-  $query = "+mods_name_personal_displayForm_mt:\"($identifier)\"  {$base_query[$type]}";
+  $query = "+mods_name_personal_displayForm_mt:\"($identifier)\" AND {$base_query[$type]}";
 
   $params = array(
     'fl' => 'dc.title, mods_name_personal_displayForm_mt, PID',
-    'sort' => variable_get('islandora_entities_query_sort', ''),
   );
+  if (strlen(variable_get('islandora_entities_query_sort', '')) > 0) {
+    $params['sort'] = variable_get('islandora_entities_query_sort', '');
+  }
 
   $qp = new IslandoraSolrQueryProcessor();
   $qp->buildAndExecuteQuery($query, $params);
@@ -222,12 +229,14 @@ function islandora_entities_get_related_pids($identifier, $title, $type) {
     watchdog_exception('Islandora Entities', $e, 'Got an exception while searching entities for callback.', array(), WATCHDOG_ERROR);
   }
   $results = array();
-  foreach ($search_results as $choice) {
-    $results[$choice['PID']] = array(
-      'PID' => $choice['PID'],
-      'title' => $choice['solr_doc']['dc.title'],
-      'authors' => $choice['solr_doc']['mods_name_personal_displayForm_mt'],
-    );
+  if ($search_results) {
+    foreach ($search_results as $choice) {
+      $results[$choice['PID']] = array(
+        'PID' => $choice['PID'],
+        'title' => $choice['solr_doc']['dc.title'],
+        'authors' => $choice['solr_doc']['mods_name_personal_displayForm_mt'],
+      );
+    }
   }
   return $results;
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -123,6 +123,7 @@ function islandora_entities_create_citation_tab(AbstractObject $object) {
  *   Array of links pointing to citations
  */
 function islandora_entities_get_related($identifier, $title, $type) {
+  module_load_include('inc', 'islandora_solr', 'includes/query_processor');
   $base_query = array(
     'citations' => variable_get(
       'islandora_entities_citation_base_query',
@@ -137,18 +138,16 @@ function islandora_entities_get_related($identifier, $title, $type) {
     'sort' => variable_get('islandora_entities_query_sort', ''),
   );
 
-  $url = parse_url(variable_get('islandora_solr_url', 'localhost:8080/solr'));
-  $solr = new Apache_Solr_Service($url['host'], $url['port'], $url['path'] . '/');
-  $solr->setCreateDocuments(FALSE);
+  $qp = new IslandoraSolrQueryProcessor();
+  $qp->buildAndExecuteQuery($query, $params);
   try {
-    $results = $solr->search($query, 0, 20, $params);
-    $json = json_decode($results->getRawResponse(), TRUE);
+    $results = $qp->islandoraSolrResult['response']['docs'];
   }
   catch (Exception $e) {
     watchdog_exception('Islandora Entities', $e, 'Got an exception while searching entities for callback.', array(), WATCHDOG_ERROR);
   }
   $links = array();
-  foreach ($json['response']['docs'] as $choice) {
+  foreach ($results as $choice) {
     if (isset($choice['dc.title'])) {
       $links[] = l($choice['dc.title'][0], 'islandora/object/' . $choice['PID']);
     }
@@ -198,6 +197,7 @@ function islandora_entities_create_theses_tab(AbstractObject $object) {
  *   Array of links pointing to citations
  */
 function islandora_entities_get_related_pids($identifier, $title, $type) {
+  module_load_include('inc', 'islandora_solr', 'includes/query_processor');
   $base_query = array(
     'citations' => variable_get(
       'islandora_entities_citation_base_query',
@@ -213,18 +213,16 @@ function islandora_entities_get_related_pids($identifier, $title, $type) {
     'sort' => variable_get('islandora_entities_query_sort', ''),
   );
 
-  $url = parse_url(variable_get('islandora_solr_url', 'localhost:8080/solr'));
-  $solr = new Apache_Solr_Service($url['host'], $url['port'], $url['path'] . '/');
-  $solr->setCreateDocuments(FALSE);
+  $qp = new IslandoraSolrQueryProcessor();
+  $qp->buildAndExecuteQuery($query, $params);
   try {
-    $search_results = $solr->search($query, 0, 20, $params);
-    $json = json_decode($search_results->getRawResponse(), TRUE);
+    $search_results = $qp->islandoraSolrResult['response']['docs'];
   }
   catch (Exception $e) {
     watchdog_exception('Islandora Entities', $e, 'Got an exception while searching entities for callback.', array(), WATCHDOG_ERROR);
   }
   $results = array();
-  foreach ($json['response']['docs'] as $choice) {
+  foreach ($search_results as $choice) {
     $results[$choice['PID']] = array(
       'PID' => $choice['PID'],
       'title' => $choice['dc.title'],

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -141,15 +141,15 @@ function islandora_entities_get_related($identifier, $title, $type) {
   $qp = new IslandoraSolrQueryProcessor();
   $qp->buildAndExecuteQuery($query, $params);
   try {
-    $results = $qp->islandoraSolrResult['response']['docs'];
+    $results = $qp->islandoraSolrResult['response']['objects'];
   }
   catch (Exception $e) {
     watchdog_exception('Islandora Entities', $e, 'Got an exception while searching entities for callback.', array(), WATCHDOG_ERROR);
   }
   $links = array();
   foreach ($results as $choice) {
-    if (isset($choice['dc.title'])) {
-      $links[] = l($choice['dc.title'][0], 'islandora/object/' . $choice['PID']);
+    if (isset($choice['solr_doc']['dc.title'])) {
+      $links[] = l($choice['solr_doc']['dc.title'][0], 'islandora/object/' . $choice['PID']);
     }
   }
   if (count($links) > 0) {
@@ -216,7 +216,7 @@ function islandora_entities_get_related_pids($identifier, $title, $type) {
   $qp = new IslandoraSolrQueryProcessor();
   $qp->buildAndExecuteQuery($query, $params);
   try {
-    $search_results = $qp->islandoraSolrResult['response']['docs'];
+    $search_results = $qp->islandoraSolrResult['response']['objects'];
   }
   catch (Exception $e) {
     watchdog_exception('Islandora Entities', $e, 'Got an exception while searching entities for callback.', array(), WATCHDOG_ERROR);
@@ -225,8 +225,8 @@ function islandora_entities_get_related_pids($identifier, $title, $type) {
   foreach ($search_results as $choice) {
     $results[$choice['PID']] = array(
       'PID' => $choice['PID'],
-      'title' => $choice['dc.title'],
-      'authors' => $choice['mods_name_personal_displayForm_mt'],
+      'title' => $choice['solr_doc']['dc.title'],
+      'authors' => $choice['solr_doc']['mods_name_personal_displayForm_mt'],
     );
   }
   return $results;

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -134,6 +134,7 @@ function islandora_entities_get_related($identifier, $title, $type) {
   $query = "+mods_name_personal_displayForm_mt:\"($identifier)\"  {$base_query[$type]}";
   $params = array(
     'fl' => 'dc.title, PID',
+    'sort' => variable_get('islandora_entities_query_sort', ''),
   );
 
   $url = parse_url(variable_get('islandora_solr_url', 'localhost:8080/solr'));
@@ -209,6 +210,7 @@ function islandora_entities_get_related_pids($identifier, $title, $type) {
 
   $params = array(
     'fl' => 'dc.title, mods_name_personal_displayForm_mt, PID',
+    'sort' => variable_get('islandora_entities_query_sort', ''),
   );
 
   $url = parse_url(variable_get('islandora_solr_url', 'localhost:8080/solr'));

--- a/islandora_entities.install
+++ b/islandora_entities.install
@@ -31,6 +31,7 @@ function islandora_entities_uninstall() {
     'islandora_entities_department_solr_field',
     'islandora_entities_disambiguated_solr_field',
     'islandora_entities_last_name_solr_field',
+    'islandora_entities_query_sort',
   );
   foreach ($drupal_variables as $drupal_variable) {
     variable_del($drupal_variable);

--- a/islandora_entities.module
+++ b/islandora_entities.module
@@ -107,7 +107,7 @@ function islandora_entities_menu() {
       'page callback' => 'drupal_get_form',
       'page arguments' => array('islandora_entities_citation_form', 2, 'theses'),
       'access callback' => 'islandora_entities_citation_access',
-      'access arguments' => array(2, "citations"),
+      'access arguments' => array(2, "theses"),
       'file' => 'includes/citation_tab.inc',
       'weight' => 2,
     ),

--- a/islandora_entities.module
+++ b/islandora_entities.module
@@ -612,7 +612,7 @@ function islandora_entities_citation_access($object, $type) {
       $simplexml = simplexml_load_string($mads);
       $identifiers = $simplexml->identifier;
       foreach ($identifiers as $identifier) {
-        if ($identifier['type'] == 'u1') {
+        if ($identifier['type'] == 'u1' && (string) $identifier) {
           $results = islandora_entities_get_related((string) $identifier, (string) $simplexml->authority->titleInfo->title, $type);
         }
       }

--- a/modules/islandora_entities_csv_import/includes/utilities.inc
+++ b/modules/islandora_entities_csv_import/includes/utilities.inc
@@ -317,6 +317,7 @@ function islandora_entities_attach_element($dom, $element_name, $parent_node, $c
  *   Contents of textfield being completed
  */
 function islandora_entities_get_collection_autocomplete($string = '') {
+  module_load_include('inc', 'islandora_solr', 'includes/query_processor');
   $string = str_replace(':', '\:', $string);
   $params = array(
     'fl' => array('dc.title, PID'),
@@ -324,18 +325,16 @@ function islandora_entities_get_collection_autocomplete($string = '') {
   $string = $string ? " +dc.title:$string*" : '';
   $query = '(+RELS_EXT_hasModel_uri_ms:"info:fedora/islandora:collectionCModel"' . $string . ')';
   $query .= '(+RELS_EXT_hasModel_uri_ms:"info:fedora/islandora:collectionCModel"' . str_replace('dc.title', 'PID', $string) . ')';
-  $url = parse_url(variable_get('islandora_solr_url', 'localhost:8080/solr'));
-  $solr = new Apache_Solr_Service($url['host'], $url['port'], $url['path'] . '/');
-  $solr->setCreateDocuments(FALSE);
+  $qp = new IslandoraSolrQueryProcessor();
+  $qp->buildAndExecuteQuery($query, $params);
   try {
-    $results = $solr->search($query, 0, 1000, $params);
-    $json = json_decode($results->getRawResponse(), TRUE);
+    $results = $qp->islandoraSolrResult['response']['docs'];
   }
   catch (Exception $e) {
     watchdog_exception('Islandora Entities', $e, 'Got an exception while searching entities for callback.', array(), WATCHDOG_ERROR);
   }
   $list = array();
-  foreach ($json['response']['docs'] as $choice) {
+  foreach ($results as $choice) {
     $list[$choice['PID']] = $choice['dc.title'][0] . " ~ " . $choice['PID'];
   }
 

--- a/modules/islandora_entities_csv_import/includes/utilities.inc
+++ b/modules/islandora_entities_csv_import/includes/utilities.inc
@@ -322,9 +322,9 @@ function islandora_entities_get_collection_autocomplete($string = '') {
   $params = array(
     'fl' => array('dc.title, PID'),
   );
-  $string = $string ? " +dc.title:$string*" : '';
-  $query = '(+RELS_EXT_hasModel_uri_ms:"info:fedora/islandora:collectionCModel"' . $string . ')';
-  $query .= '(+RELS_EXT_hasModel_uri_ms:"info:fedora/islandora:collectionCModel"' . str_replace('dc.title', 'PID', $string) . ')';
+  $string = $string ? " %2Bdc.title:$string*" : '';
+  $query = '(%2BRELS_EXT_hasModel_uri_ms:"info:fedora/islandora:collectionCModel"' . $string . ')';
+  $query .= '(%2BRELS_EXT_hasModel_uri_ms:"info:fedora/islandora:collectionCModel"' . str_replace('dc.title', 'PID', $string) . ')';
   $qp = new IslandoraSolrQueryProcessor();
   $qp->buildAndExecuteQuery($query, $params);
   try {

--- a/modules/islandora_entities_csv_import/includes/utilities.inc
+++ b/modules/islandora_entities_csv_import/includes/utilities.inc
@@ -328,14 +328,14 @@ function islandora_entities_get_collection_autocomplete($string = '') {
   $qp = new IslandoraSolrQueryProcessor();
   $qp->buildAndExecuteQuery($query, $params);
   try {
-    $results = $qp->islandoraSolrResult['response']['docs'];
+    $results = $qp->islandoraSolrResult['response']['objects'];
   }
   catch (Exception $e) {
     watchdog_exception('Islandora Entities', $e, 'Got an exception while searching entities for callback.', array(), WATCHDOG_ERROR);
   }
   $list = array();
   foreach ($results as $choice) {
-    $list[$choice['PID']] = $choice['dc.title'][0] . " ~ " . $choice['PID'];
+    $list[$choice['PID']] = $choice['solr_doc']['dc.title'][0] . " ~ " . $choice['PID'];
   }
 
   drupal_json_output($list);

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -121,22 +121,21 @@ function islandora_entities_preprocess_islandora_person(array &$variables) {
  *   Department members
  */
 function islandora_entities_get_dept_members($dept, $pid) {
+  module_load_include('inc', 'islandora_solr', 'includes/query_processor');
   $params = array(
     'fl' => array('MADS_title_ms PID'),
   );
   $query = "MADS_organization_ms:\"$dept\" AND -PID:\"$pid\"";
-  $url = parse_url(variable_get('islandora_solr_url', 'localhost:8080/solr'));
-  $solr = new Apache_Solr_Service($url['host'], $url['port'], $url['path'] . '/');
-  $solr->setCreateDocuments(FALSE);
+  $qp = new IslandoraSolrQueryProcessor();
+  $qp->buildAndExecuteQuery($query, $params);
   try {
-    $results = $solr->search($query, 0, 1000, $params);
-    $json = json_decode($results->getRawResponse(), TRUE);
+    $results = $qp->islandoraSolrResult['response']['docs'];
   }
   catch (Exception $e) {
     watchdog_exception('Islandora Entities', $e, 'Got an exception while searching entities for callback.', array(), WATCHDOG_ERROR);
   }
   $colleages = array();
-  foreach ($json['response']['docs'] as $choice) {
+  foreach ($results as $choice) {
     if (isset($choice['MADS_title_ms'])) {
       foreach ($choice['MADS_title_ms'] as $candidate) {
         $colleages[$choice['PID']] = $candidate;

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -129,15 +129,15 @@ function islandora_entities_get_dept_members($dept, $pid) {
   $qp = new IslandoraSolrQueryProcessor();
   $qp->buildAndExecuteQuery($query, $params);
   try {
-    $results = $qp->islandoraSolrResult['response']['docs'];
+    $results = $qp->islandoraSolrResult['response']['objects'];
   }
   catch (Exception $e) {
     watchdog_exception('Islandora Entities', $e, 'Got an exception while searching entities for callback.', array(), WATCHDOG_ERROR);
   }
   $colleages = array();
   foreach ($results as $choice) {
-    if (isset($choice['MADS_title_ms'])) {
-      foreach ($choice['MADS_title_ms'] as $candidate) {
+    if (isset($choice['solr_doc']['MADS_title_ms'])) {
+      foreach ($choice['solr_doc']['MADS_title_ms'] as $candidate) {
         $colleages[$choice['PID']] = $candidate;
       }
     }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1594

# What does this Pull Request do?

Change the Islandora_solr_entities to use the IslandoraSolrQueryProcessor to build queries.

# What's new?
Build and execute queries using the IslandoraSolrQueryProcessor and therefore apply filters and namespace restrictions.

Also @rosiel added some fixes to account for IslandoraSolrQueryProcessor stripping +'s

# How should this be tested?

This should not have a large effect unless you use namespace restrictions in which case entities from other namespaces should not be accessible.

# Additional Notes:
I apologize that I don't really use this module and @rosiel while "reviewing" my initial branch ended up fixing (hopefully) most of the problems. So if there is someone that uses entities that could have a look that would be great.


Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@Islandora/7-x-1-x-committers, @nhart (opening the ticket), @bryjbrown (as an avid scholar users)
