### PR TITLE
ISLANDORA-1582 url in metadata doesn't link to solr search.

### DIFF
--- a/islandora_entities.install
+++ b/islandora_entities.install
@@ -122,7 +122,7 @@ function islandora_entities_get_scholar_config_fields() {
   $fields['MADS_url_ms'] = array(
     'remove_field' => 0,
     'display_label' => 'URL',
-    'hyperlink' => 1,
+    'hyperlink' => 0,
     'weight' => ++$weight,
     'solr_field' => 'MADS_url_ms',
   );
@@ -165,7 +165,7 @@ function islandora_entities_get_dept_config_fields() {
   $fields['MADS_url_ms'] = array(
     'remove_field' => 0,
     'display_label' => 'URL',
-    'hyperlink' => 1,
+    'hyperlink' => 0,
     'weight' => ++$weight,
     'solr_field' => 'MADS_url_ms',
   );


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1582

# What does this Pull Request do?

Fixes the out-of-the-box Solr Metadata configurations for "scholars" and "department" that get installed when you install the entities solution pack. 

# What's new?

The "url" field used to be configured as a hyperlink, which was clearly an accident because that made it a hyperlink to a solr search for the value of the URL, instead of a hyperlink to the URL itself. This change means that in **new installations of entities solution pack** the field will be configured correctly. Anyone with an existing installation will not be affected, and will have to uncheck the "Hyperlink" configuration for these fields if they want to fix it.

# How should this be tested?

To reproduce the problem: Create a scholar or department with a URL in the MADS form, and enable solr metadata (rather than DC) on a fresh box.
After this pull request: Nothing will change on your existing box, sorry. To test please uninstall Entities SP, **delete the solr metadata configurations** then re-install entities SP. 

# Additional Notes:

* Does this change require documentation to be updated?  **no**
* Does this change add any new dependencies?  **no**
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? **no**
* Could this change impact execution of existing code? **no**

# Interested parties
@bryjbrown and @bondjimbond

Release PR: https://github.com/Islandora/islandora_solution_pack_entities/pull/115
