### PR TITLE
ISLANDORA-1989 Adds autocomplete to solr sort field in admin form

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -152,9 +152,12 @@ function islandora_entities_settings($form, &$form_state) {
     '#type' => 'radios',
     '#title' => t('Sort direction'),
     '#description' => t('Sort direction for citations and theses on scholar profile pages.'),
-    '#default_value' => variable_get('islandora_entities_query_sort_direction', 0),
+    '#default_value' => variable_get('islandora_entities_query_sort_direction', 'asc'),
     '#required' => FALSE,
-    '#options' => array(t('Ascending'), t('Descending')),
+    '#options' => array(
+      'asc' => t('Ascending'),
+      'desc' => t('Descending'),
+    ),
   );
 
   $form['islandora_entities_citation_number'] = array(

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -143,8 +143,18 @@ function islandora_entities_settings($form, &$form_state) {
       'islandora_entities_query_sort',
       ''
     ),
-    '#description' => t('Used to sort citations and theses on scholar profile pages. Should contain the solr field followed by a space and either "asc" or "desc". For example, "mods_originInfo_keyDate_yes_dateIssued_dt asc" will sort on the dateIssued field in ascending order.'),
+    '#description' => t('Used to sort citations and theses on scholar profile pages.'),
     '#required' => FALSE,
+    '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
+  );
+
+  $form['islandora_entities_query_sort_direction'] = array(
+    '#type' => 'radios',
+    '#title' => t('Sort direction'),
+    '#description' => t('Sort direction for citations and theses on scholar profile pages.'),
+    '#default_value' => variable_get('islandora_entities_query_sort_direction', 0),
+    '#required' => FALSE,
+    '#options' => array(t('Ascending'), t('Descending')),
   );
 
   $form['islandora_entities_citation_number'] = array(

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -122,8 +122,6 @@ function islandora_entities_create_citation_tab(AbstractObject $object) {
  *   Array of links pointing to citations
  */
 function islandora_entities_get_related($identifier, $title, $type) {
-  $sort_directions = array('asc', 'desc');
-
   $base_query = array(
     'citations' => variable_get(
       'islandora_entities_citation_base_query',
@@ -139,7 +137,7 @@ function islandora_entities_get_related($identifier, $title, $type) {
   );
   if (strlen(variable_get('islandora_entities_query_sort', '')) > 0) {
     $params['sort'] = variable_get('islandora_entities_query_sort', '')
-      . ' ' . $sort_directions[variable_get('islandora_entities_query_sort_direction', 0)];
+      . ' ' . variable_get('islandora_entities_query_sort_direction', 'asc');
   }
 
   $qp = new IslandoraSolrQueryProcessor();
@@ -207,8 +205,6 @@ function islandora_entities_create_theses_tab(AbstractObject $object) {
  *   Array of links pointing to citations
  */
 function islandora_entities_get_related_pids($identifier, $title, $type) {
-  $sort_directions = array('asc', 'desc');
-
   $base_query = array(
     'citations' => variable_get(
       'islandora_entities_citation_base_query',
@@ -225,7 +221,7 @@ function islandora_entities_get_related_pids($identifier, $title, $type) {
   );
   if (strlen(variable_get('islandora_entities_query_sort', '')) > 0) {
     $params['sort'] = variable_get('islandora_entities_query_sort', '')
-      . ' ' . $sort_directions[variable_get('islandora_entities_query_sort_direction', 0)];
+      . ' ' . variable_get('islandora_entities_query_sort_direction', 'asc');
   }
 
   $qp = new IslandoraSolrQueryProcessor();

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -122,6 +122,8 @@ function islandora_entities_create_citation_tab(AbstractObject $object) {
  *   Array of links pointing to citations
  */
 function islandora_entities_get_related($identifier, $title, $type) {
+  $sort_directions = array('asc', 'desc');
+
   $base_query = array(
     'citations' => variable_get(
       'islandora_entities_citation_base_query',
@@ -136,7 +138,8 @@ function islandora_entities_get_related($identifier, $title, $type) {
     'limit' => variable_get('islandora_entities_citation_number', '20'),
   );
   if (strlen(variable_get('islandora_entities_query_sort', '')) > 0) {
-    $params['sort'] = variable_get('islandora_entities_query_sort', '');
+    $params['sort'] = variable_get('islandora_entities_query_sort', '')
+      . ' ' . $sort_directions[variable_get('islandora_entities_query_sort_direction', 0)];
   }
 
   $qp = new IslandoraSolrQueryProcessor();
@@ -204,6 +207,8 @@ function islandora_entities_create_theses_tab(AbstractObject $object) {
  *   Array of links pointing to citations
  */
 function islandora_entities_get_related_pids($identifier, $title, $type) {
+  $sort_directions = array('asc', 'desc');
+
   $base_query = array(
     'citations' => variable_get(
       'islandora_entities_citation_base_query',
@@ -219,7 +224,8 @@ function islandora_entities_get_related_pids($identifier, $title, $type) {
     'limit' => variable_get('islandora_entities_citation_number', '20'),
   );
   if (strlen(variable_get('islandora_entities_query_sort', '')) > 0) {
-    $params['sort'] = variable_get('islandora_entities_query_sort', '');
+    $params['sort'] = variable_get('islandora_entities_query_sort', '')
+      . ' ' . $sort_directions[variable_get('islandora_entities_query_sort_direction', 0)];
   }
 
   $qp = new IslandoraSolrQueryProcessor();

--- a/islandora_entities.install
+++ b/islandora_entities.install
@@ -32,6 +32,7 @@ function islandora_entities_uninstall() {
     'islandora_entities_disambiguated_solr_field',
     'islandora_entities_last_name_solr_field',
     'islandora_entities_query_sort',
+    'islandora_entities_query_sort_direction',
     'islandora_entities_citation_number',
   );
   foreach ($drupal_variables as $drupal_variable) {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1989

# What does this Pull Request do?

Adds autocomplete to the Solr sort field in the admin form and separates the choosing of ascending and descending into it's own option.

# What's new?

* Autocomplete on one field in the admin form.
* One new field in the admin form to choose the sort direction.

# How should this be tested?

1. Go into the admin form and choose a Solr field to sort on.
2. Go to a scholar profile and confirm that the citations are sorted.
3. Click the citations and theses tabs and confirm that they are also sorted.

# Additional Notes:

This was suggested in Jira ticket https://jira.duraspace.org/browse/ISLANDORA-1883

Documentation should be updated to include the new options.

# Interested parties
@Islandora/7-x-1-x-committers