### PR TITLE
ISLANDORA-1837: Add configurable Solr field to link Citation and Thes…

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -164,6 +164,18 @@ function islandora_entities_settings($form, &$form_state) {
     '#required' => TRUE,
   );
 
+  $form['islandora_entities_citation_author_solr_field'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Solr field for author of citations and theses.'),
+    '#default_value' => variable_get(
+      'islandora_entities_citation_author_solr_field',
+      'mods_name_personal_displayForm_mt'
+    ),
+    '#description' => t('Solr field to display as author under the Citation and Theses tabs.'),
+    '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
+    '#required' => TRUE,
+  );
+
   $form['islandora_entities_linking_content_solr_field'] = array(
     '#type' => 'textfield',
     '#title' => t('Solr field for linking content to person entities.'),

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -25,6 +25,7 @@ function islandora_entities_settings($form, &$form_state) {
       'eaccpf_name_complete_et'
     ),
     '#description' => t('Solr Field for entity searching.'),
+    '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
     '#required' => TRUE,
   );
 
@@ -100,6 +101,7 @@ function islandora_entities_settings($form, &$form_state) {
       'MADS_title_mt'
     ),
     '#description' => t('Solr field for autocompletion.'),
+    '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
     '#required' => TRUE,
   );
 
@@ -111,6 +113,7 @@ function islandora_entities_settings($form, &$form_state) {
       'MADS_department_mt'
     ),
     '#description' => t('Solr field for autocompletion.'),
+    '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
     '#required' => TRUE,
   );
 
@@ -122,6 +125,7 @@ function islandora_entities_settings($form, &$form_state) {
       'MADS_disambiguated_fullname_mt'
     ),
     '#description' => t('Solr field for autocompletion.'),
+    '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
     '#required' => TRUE,
   );
 
@@ -133,6 +137,7 @@ function islandora_entities_settings($form, &$form_state) {
       'MADS_family_mt'
     ),
     '#description' => t('Solr field for autocompletion.'),
+    '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
     '#required' => TRUE,
   );
 
@@ -144,6 +149,7 @@ function islandora_entities_settings($form, &$form_state) {
       ''
     ),
     '#description' => t('Used to sort citations and theses on scholar profile pages. Should contain the solr field followed by a space and either "asc" or "desc". For example, "mods_originInfo_keyDate_yes_dateIssued_dt asc" will sort on the dateIssued field in ascending order.'),
+    '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
     '#required' => FALSE,
   );
 
@@ -166,6 +172,7 @@ function islandora_entities_settings($form, &$form_state) {
       'mods_name_personal_displayForm_mt'
     ),
     '#description' => t('Solr field used to link citations and theses to person entities.'),
+    '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
     '#required' => TRUE,
   );
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -158,5 +158,16 @@ function islandora_entities_settings($form, &$form_state) {
     '#required' => TRUE,
   );
 
+  $form['islandora_entities_linking_content_solr_field'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Solr field for linking content to person entities.'),
+    '#default_value' => variable_get(
+      'islandora_entities_linking_content_solr_field',
+      'mods_name_personal_displayForm_mt'
+    ),
+    '#description' => t('Solr field used to link citations and theses to person entities.'),
+    '#required' => TRUE,
+  );
+
   return system_settings_form($form);
 }

--- a/includes/entities_rss.inc
+++ b/includes/entities_rss.inc
@@ -68,7 +68,10 @@ function islandora_entities_get_rss_related($identifier, $type) {
   $params = array(
     'fl' => 'dc.title, PID, dc.description',
   );
-  $query = "RELS_EXT_hasModel_uri_mt:\"$content_model\" AND mods_name_personal_displayForm_mt:\"($identifier)\"";
+  $entities_linking_field = variable_get(
+      'islandora_entities_linking_content_solr_field', 'mods_name_personal_displayForm_mt'
+  );
+  $query = "RELS_EXT_hasModel_uri_mt:\"$content_model\" AND {$entities_linking_field}:\"($identifier)\"";
 
   $qp = new IslandoraSolrQueryProcessor();
   $qp->buildAndExecuteQuery($query, $params);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -218,10 +218,13 @@ function islandora_entities_get_related_pids($identifier, $title, $type) {
   $entities_linking_field = variable_get(
       'islandora_entities_linking_content_solr_field', 'mods_name_personal_displayForm_mt'
   );
+  $author_field = variable_get(
+      'islandora_entities_citation_author_solr_field', 'mods_name_personal_displayForm_mt'
+  );
   $query = "+{$entities_linking_field}:\"($identifier)\" AND {$base_query[$type]}";
 
   $params = array(
-    'fl' => 'dc.title, mods_name_personal_displayForm_mt, PID',
+    'fl' => 'dc.title, {$author_field}, PID',
     'limit' => variable_get('islandora_entities_citation_number', '20'),
   );
   if (strlen(variable_get('islandora_entities_query_sort', '')) > 0) {
@@ -243,7 +246,7 @@ function islandora_entities_get_related_pids($identifier, $title, $type) {
       $results[$choice['PID']] = array(
         'PID' => $choice['PID'],
         'title' => $choice['solr_doc']['dc.title'],
-        'authors' => isset($choice['solr_doc']['mods_name_personal_displayForm_mt']) ? $choice['solr_doc']['mods_name_personal_displayForm_mt'] : array(),
+        'authors' => isset($choice['solr_doc'][$author_field]) ? $choice['solr_doc'][$author_field] : array(),
       );
     }
   }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -130,7 +130,10 @@ function islandora_entities_get_related($identifier, $title, $type) {
       'islandora_entities_thesis_base_query',
       '+RELS_EXT_hasModel_uri_mt:"ir:thesisCModel"'),
   );
-  $query = "+mods_name_personal_displayForm_mt:\"($identifier)\" AND {$base_query[$type]}";
+  $entities_linking_field = variable_get(
+      'islandora_entities_linking_content_solr_field', 'mods_name_personal_displayForm_mt'
+  );
+  $query = "+{$entities_linking_field}:\"($identifier)\" AND {$base_query[$type]}";
   $params = array(
     'fl' => 'dc.title, PID',
     'limit' => variable_get('islandora_entities_citation_number', '20'),
@@ -212,10 +215,13 @@ function islandora_entities_get_related_pids($identifier, $title, $type) {
       'islandora_entities_thesis_base_query',
       '+RELS_EXT_hasModel_uri_mt:"ir:thesisCModel"'),
   );
-  $query = "+mods_name_personal_displayForm_mt:\"($identifier)\" AND {$base_query[$type]}";
+  $entities_linking_field = variable_get(
+      'islandora_entities_linking_content_solr_field', 'mods_name_personal_displayForm_mt'
+  );
+  $query = "+{$entities_linking_field}:\"($identifier)\" AND {$base_query[$type]}";
 
   $params = array(
-    'fl' => 'dc.title, mods_name_personal_displayForm_mt, PID',
+    'fl' => 'dc.title, {$entities_linking_field}, PID',
     'limit' => variable_get('islandora_entities_citation_number', '20'),
   );
   if (strlen(variable_get('islandora_entities_query_sort', '')) > 0) {
@@ -237,7 +243,7 @@ function islandora_entities_get_related_pids($identifier, $title, $type) {
       $results[$choice['PID']] = array(
         'PID' => $choice['PID'],
         'title' => $choice['solr_doc']['dc.title'],
-        'authors' => $choice['solr_doc']['mods_name_personal_displayForm_mt'],
+        'authors' => $choice['solr_doc'][$entities_linking_field],
       );
     }
   }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -221,7 +221,7 @@ function islandora_entities_get_related_pids($identifier, $title, $type) {
   $query = "+{$entities_linking_field}:\"($identifier)\" AND {$base_query[$type]}";
 
   $params = array(
-    'fl' => 'dc.title, {$entities_linking_field}, PID',
+    'fl' => 'dc.title, mods_name_personal_displayForm_mt, PID',
     'limit' => variable_get('islandora_entities_citation_number', '20'),
   );
   if (strlen(variable_get('islandora_entities_query_sort', '')) > 0) {
@@ -243,7 +243,7 @@ function islandora_entities_get_related_pids($identifier, $title, $type) {
       $results[$choice['PID']] = array(
         'PID' => $choice['PID'],
         'title' => $choice['solr_doc']['dc.title'],
-        'authors' => $choice['solr_doc'][$entities_linking_field],
+        'authors' => isset($choice['solr_doc']['mods_name_personal_displayForm_mt']) ? $choice['solr_doc']['mods_name_personal_displayForm_mt'] : array(),
       );
     }
   }

--- a/islandora_entities.install
+++ b/islandora_entities.install
@@ -33,6 +33,7 @@ function islandora_entities_uninstall() {
     'islandora_entities_last_name_solr_field',
     'islandora_entities_query_sort',
     'islandora_entities_citation_number',
+    'islandora_entities_citation_author_solr_field',
     'islandora_entities_linking_content_solr_field',
   );
   foreach ($drupal_variables as $drupal_variable) {

--- a/islandora_entities.install
+++ b/islandora_entities.install
@@ -33,6 +33,7 @@ function islandora_entities_uninstall() {
     'islandora_entities_last_name_solr_field',
     'islandora_entities_query_sort',
     'islandora_entities_citation_number',
+    'islandora_entities_linking_content_solr_field',
   );
   foreach ($drupal_variables as $drupal_variable) {
     variable_del($drupal_variable);


### PR DESCRIPTION
…is objects to Person entities

* Add variable to configuration form with default set to current value (mods_name_personal_displayForm_mt)

* Use variable in queries for RSS feed, citations tab, and theses tab

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1837

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

A related pull request will be made to the islandora_scholar module to add name/nameIdentifier to the default Citation and Thesis forms.

# What does this Pull Request do?

The JIRA ticket notes that the linking of Person entities to Citation and Thesis objects is not well documented and accomplished in code with hard-coded queries of the Solr field mods_name_personal_displayForm_mt.  This pull request makes the Solr field configurable and allows the user to specify which MODS element to use for linking.

# What's new?

This pull request adds a variable to configure the Solr field to use for linking of Person entities to Citation and Thesis objects, with its default value set to mods_name_personal_displayForm_mt.  This pull request replaces the hard-coded value with the variable in queries for RSS feed, citation tab, and theses tab.  

The default behavior should be unchanged.  Users that choose to use a different Solr field should verify that the field exists and that it contains the correct value.

# How should this be tested?

Create a Person object with an identifier.  Create a Citation object and a Thesis object, with that person's identifer defined in the MODS element you want to use for linking the person to the object.  After ingest, confirm the name of the Solr field containing the identifer.  In the Entity module configuration form, under "Solr field for linking content to person entities" replace mods_name_personal_displayForm_mt with the name of the Solr field that contains the identifier.  View the RSS feed, Citations tab, and Theses tab to verify the correct objects are listed.

# Interested parties
@Islandora/7-x-1-x-committers
