### PR TITLE
Islandora 1244 use configurable description field.

### DIFF
--- a/islandora_entities.install
+++ b/islandora_entities.install
@@ -196,6 +196,7 @@ function islandora_entities_get_dept_config_fields() {
  * Add the default description field to the Scholar solr metadata profile.
  */
 function islandora_entities_update_7100() {
+  module_load_include('inc', 'islandora_solr_metadata', 'includes/db');
   $config_id = islandora_solr_metadata_retrieve_configuration_from_machine_name('Scholar');
   if ($config_id) {
     $description = islandora_solr_metadata_retrieve_description($config_id);

--- a/islandora_entities.install
+++ b/islandora_entities.install
@@ -64,6 +64,7 @@ function islandora_entities_install_solr_metadata_config($config_name, $machine_
   $configuration_id = islandora_solr_metadata_add_configuration($config_name, $machine_name);
   islandora_solr_metadata_add_content_models($configuration_id, $configs['cmodels']);
   islandora_solr_metadata_add_fields($configuration_id, $configs['fields']);
+  islandora_solr_metadata_update_description($configuration_id, $configs['description']['field'], $configs['description']['display_label'], $configs['description']['data']);
   drupal_set_message($t("Configuration '@config' installed.", array('@config' => $config_name)));
 }
 
@@ -129,6 +130,11 @@ function islandora_entities_get_scholar_config_fields() {
     'weight' => ++$weight,
     'solr_field' => 'MADS_url_ms',
   );
+  $configs['description'] = array(
+    'field' => 'MADS_history_ms',
+    'display_label' => 'Biography',
+    'data' => array(),
+  );
   $configs['fields'] = $fields;
   $configs['cmodels'] = $content_models;
   return $configs;
@@ -184,4 +190,15 @@ function islandora_entities_get_dept_config_fields() {
   $configs['fields'] = $fields;
   $configs['cmodels'] = $content_models;
   return $configs;
+}
+
+/* Add the default description field to the Scholar solr metadata profile. */
+function islandora_entities_update_7100() {
+  $config_id = islandora_solr_metadata_retrieve_configuration_from_machine_name('Scholar');
+  if ($config_id) {
+    $description = islandora_solr_metadata_retrieve_description($config_id);
+    if (!$description['description_field']) {
+      islandora_solr_metadata_update_description($config_id, 'MADS_history_ms','Biography', $description['data']);
+    }
+  }
 }

--- a/islandora_entities.install
+++ b/islandora_entities.install
@@ -192,13 +192,15 @@ function islandora_entities_get_dept_config_fields() {
   return $configs;
 }
 
-/* Add the default description field to the Scholar solr metadata profile. */
+/**
+ * Add the default description field to the Scholar solr metadata profile.
+ */
 function islandora_entities_update_7100() {
   $config_id = islandora_solr_metadata_retrieve_configuration_from_machine_name('Scholar');
   if ($config_id) {
     $description = islandora_solr_metadata_retrieve_description($config_id);
     if (!$description['description_field']) {
-      islandora_solr_metadata_update_description($config_id, 'MADS_history_ms','Biography', $description['data']);
+      islandora_solr_metadata_update_description($config_id, 'MADS_history_ms', 'Biography', $description['data']);
     }
   }
 }

--- a/theme/islandora-person.tpl.php
+++ b/theme/islandora-person.tpl.php
@@ -36,7 +36,7 @@
 
   <div class="islandora-object-content">
     <?php if (isset($variables['description'])): ?>
-      <p><?php print $variables['description']; ?></p>
+      <?php print $variables['description']; ?>
     <?php endif; ?>
 
     <?php if (isset($variables['recent_citations'])): ?>

--- a/theme/islandora-person.tpl.php
+++ b/theme/islandora-person.tpl.php
@@ -35,9 +35,8 @@
   </div>
 
   <div class="islandora-object-content">
-    <h3 class="bio"><?php print t('Biography'); ?></h3>
-    <?php if (isset($variables['biography'])): ?>
-      <p><?php print $variables['biography']; ?></p>
+    <?php if (isset($variables['description'])): ?>
+      <p><?php print $variables['description']; ?></p>
     <?php endif; ?>
 
     <?php if (isset($variables['recent_citations'])): ?>

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -22,6 +22,10 @@ function template_preprocess_islandora_person(array &$variables) {
   if ($object['MADS']) {
     $mads = $object['MADS']->content;
     $simplexml = simplexml_load_string($mads);
+    // $variables['biography'] is a legacy feature using hard-coded
+    // xml paths. The default template now uses $variables['description'].
+    // This is kept for backwards compatibility with existing custom
+    // templates that may use it.
     $notes = $simplexml->note;
     foreach ($notes as $note) {
       if ($note['type'] == 'history') {
@@ -106,6 +110,8 @@ function template_preprocess_islandora_person(array &$variables) {
   if ($object['TN']) {
     $variables['tn'] = url("islandora/object/{$object->id}/datastream/TN/view");
   }
+  $description = islandora_retrieve_description_markup($object);
+  $variables['description'] = $description;
   $variables['metadata'] = islandora_retrieve_metadata_markup($object, TRUE);
 }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1244

Discussed on Committers call March 8, 2018.

# What does this Pull Request do?

Uses the standard Islandora way of getting a description for the Person display page, rather than a hard-coded XPath from the MADS.

# What's new?

* Changes the "Biography" element on the template to use `islandora_retrieve_description_markup($object).` 
* Added MADS_history_ms as the default "description" field on the solr metadata config that Entities creates.

# How should this be tested?

* Create a Person object, with a description/bio/whatever *not* in a <mads:note type="history"> field.
* Enable Solr Metadata and edit the configuration for People (called "Scholar" or your custom one) to use a description solr field
* Before: You don't see your custom description because it's not in <mads:note type="history">.
* After: You see the contents of that field, and your customized label.

NOTE: this includes an update hook. If you have already configured the Scholar metadata configuration to have a description field, your configuration should remain. If you do not have a description field, one will be added (MADS_history_ms, same as what is showing as Biography right now)

# Additional Notes:

* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No - code that uses the legacy $biography variable will still work.

# Interested parties
 @Islandora/7-x-1-x-committers