### PR TITLE
ISLANDORA-2317 - Fix Scholar MADS Position options

### DIFF
--- a/xml/scholar_mads_form.xml
+++ b/xml/scholar_mads_form.xml
@@ -554,15 +554,15 @@
               <multiple>FALSE</multiple>
               <options>
                 <index key="">Select a role...</index>
-                <EmeritusFaculty>Emeritus Faculty</EmeritusFaculty>
-                <EmeritusLibrarian>Emeritus Librarian</EmeritusLibrarian>
-                <EmeritusProfessor>Emeritus Professor</EmeritusProfessor>
-                <FacultyMember>Faculty Member</FacultyMember>
+                <index key="Emeritus Faculty">Emeritus Faculty</index>
+                <index key="Emeritus Librarian">Emeritus Librarian</index>
+                <index key="Emeritus Professor">Emeritus Professor</index>
+                <index key="Faculty Member">Faculty Member</index>
                 <Librarian>Librarian</Librarian>
-                <NonAcademic>Non-Academic</NonAcademic>
+                <index key="Non-Academic">Non-Academic</index>
                 <Postdoc>Postdoc</Postdoc>
-                <GraduateStudent>Graduate Student</GraduateStudent>
-                <UndergraduateStudent>Undergraduate Student</UndergraduateStudent>
+                <index key="Graduate Student">Graduate Student</index>
+                <index key="Undergraduate Student">Undergraduate Student</index>
               </options>
               <required>FALSE</required>
               <resizable>FALSE</resizable>


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2317)

# What does this Pull Request do?

Changes the included MADS form to put spaces between the values in the select list for the Position element.

# What's new?

No more weird CamelCase values like ProfessorEmeritus and GraduateStudent.


# How should this be tested?

- Create a Person object using the form. Under Position, select a two-word role.
- See that the Position value is in CamelCase
- Check out this branch
- Create a new Person object with two-word Position
- Hooray, it looks OK
- Edit the previous Person object. Update their name and save, see what happens to Position
- Edit again, change the Position, review the MADS XML.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/7-x-1-x-committers
