### PR TITLE
Add cleanup self-transform to default forms

### DIFF
--- a/islandora_entities.module
+++ b/islandora_entities.module
@@ -320,6 +320,7 @@ function islandora_entities_xml_form_builder_form_associations() {
         'display_name',
       ),
       'transform' => 'mads_to_dc.xsl',
+      'self_transform' => 'cleanup_and_order_mads.xsl',
       'template' => FALSE,
     ),
     'islandora_mads_organization_form' => array(
@@ -332,6 +333,7 @@ function islandora_entities_xml_form_builder_form_associations() {
         'auth_dept',
       ),
       'transform' => 'mads_to_dc.xsl',
+      'self_transform' => 'cleanup_and_order_mads.xsl',
       'template' => FALSE,
     ),
   );


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2383)

# What does this Pull Request do?

Adds cleanup self-transform to the Entities SP default form associations. Provides a cleaner MADS xml datastream.

This is/will be one of many similar updates, as all of the stock forms should receive this association.

# How should this be tested?
* Ingest a test object using the MADS forms with lots of blank fields in the form; review the resulting MADS XML and see how it is filled with a horrible mass of empty XML elements
* Check out the branch
* Review the form association (form builder -> enabled associations)
* Ingest a test object with a lot of blank metadata fields and review the resulting MADS XML, see how it's less horrible than before

# Interested parties
@Islandora/7-x-1-x-committers