### PR TITLE
ISLANDORA-2317 - Fix Scholar MADS Position options (Second pass)

### DIFF
--- a/islandora_entities.install
+++ b/islandora_entities.install
@@ -212,8 +212,8 @@ function islandora_entities_update_7100() {
  */
 function islandora_entities_update_7200(&$sandbox) {
   $t = get_t();
-  watchdog('islandora_entities', 'The original default form used two-word labels in the Position element, but removed spaces in the MADS XML.  This has been fixed in 7.x-1.12. When editing existing objects with the new form, older values under Position will not be read and will be discarded.', array(), WATCHDOG_NOTICE, l(t('ISLANDORA-2137'), 'https://jira.duraspace.org/browse/ISLANDORA-2317', array('external' => TRUE)));
-  return $t('The original default form used two-word labels in the Position element, but removed spaces in the MADS XML.  This has been fixed in 7.x-1.12. When editing existing objects with the new form, older values under Position will not be read and will be discarded.  Please consult the !url for further information.',
+  watchdog('islandora_entities', 'The original default form used two-word labels in the Position element, but removed spaces in the MADS XML.  This has been fixed as of 7.x-1.13. When editing existing objects with the new form, older values under Position will not be read and will be discarded.', array(), WATCHDOG_NOTICE, l(t('ISLANDORA-2137'), 'https://jira.duraspace.org/browse/ISLANDORA-2317', array('external' => TRUE)));
+  return $t('The original default form used two-word labels in the Position element, but removed spaces in the MADS XML.  This has been fixed as of 7.x-1.13. When editing existing objects with the new form, older values under Position will not be read and will be discarded.  Please consult the !url for further information.',
     array(
       '!url' => l(t('ticket'), 'https://jira.duraspace.org/browse/ISLANDORA-2137', array('absolute' => TRUE)),
     )

--- a/islandora_entities.install
+++ b/islandora_entities.install
@@ -205,3 +205,17 @@ function islandora_entities_update_7100() {
     }
   }
 }
+/**
+ * Print and log a message about potential lost Position data.
+ *
+ * @see https://jira.duraspace.org/browse/ISLANDORA-2137
+ */
+function islandora_entities_update_7200(&$sandbox) {
+  $t = get_t();
+  watchdog('islandora_entities', 'The original default form used two-word labels in the Position element, but removed spaces in the MADS XML.  This has been fixed in 7.x-1.12. When editing existing objects with the new form, older values under Position will not be read and will be discarded.', array(), WATCHDOG_NOTICE, l(t('ISLANDORA-2137'), 'https://jira.duraspace.org/browse/ISLANDORA-2317', array('external' => TRUE)));
+  return $t('The original default form used two-word labels in the Position element, but removed spaces in the MADS XML.  This has been fixed in 7.x-1.12. When editing existing objects with the new form, older values under Position will not be read and will be discarded.  Please consult the !url for further information.',
+    array(
+      '!url' => l(t('ticket'), 'https://jira.duraspace.org/browse/ISLANDORA-2137', array('absolute' => TRUE)),
+    )
+  );
+}

--- a/xml/scholar_mads_form.xml
+++ b/xml/scholar_mads_form.xml
@@ -554,15 +554,15 @@
               <multiple>FALSE</multiple>
               <options>
                 <index key="">Select a role...</index>
-                <EmeritusFaculty>Emeritus Faculty</EmeritusFaculty>
-                <EmeritusLibrarian>Emeritus Librarian</EmeritusLibrarian>
-                <EmeritusProfessor>Emeritus Professor</EmeritusProfessor>
-                <FacultyMember>Faculty Member</FacultyMember>
+                <index key="Emeritus Faculty">Emeritus Faculty</index>
+                <index key="Emeritus Librarian">Emeritus Librarian</index>
+                <index key="Emeritus Professor">Emeritus Professor</index>
+                <index key="Faculty Member">Faculty Member</index>
                 <Librarian>Librarian</Librarian>
-                <NonAcademic>Non-Academic</NonAcademic>
+                <index key="Non-Academic">Non-Academic</index>
                 <Postdoc>Postdoc</Postdoc>
-                <GraduateStudent>Graduate Student</GraduateStudent>
-                <UndergraduateStudent>Undergraduate Student</UndergraduateStudent>
+                <index key="Graduate Student">Graduate Student</index>
+                <index key="Undergraduate Student">Undergraduate Student</index>
               </options>
               <required>FALSE</required>
               <resizable>FALSE</resizable>


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2317)

# What does this Pull Request do?

Changes the included MADS form to put spaces between the values in the select list for the Position element.

This was originally done in PR #128 but reverted because an update hook was needed and we were too close to the release to complete. Update hook has been added; I'm not sure what else is needed, so open to comments now.

# What's new?

No more weird CamelCase values like ProfessorEmeritus and GraduateStudent.

# How should this be tested?

- Create a Person object using the form. Under Position, select a two-word role.
- See that the Position value is in CamelCase
- Check out this branch
- Run update.php, check if update hook info is adequate
- Create a new Person object with two-word Position
- Hooray, it looks OK
- Edit the previous Person object. Update their name and save, see what happens to Position
- Edit again, change the Position, review the MADS XML.

# Interested parties
@Islandora/7-x-1-x-committers, @willtp87, @DonRichards 