### PR TITLE
Allow option to display all related CModels on Person objects

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -29,6 +29,14 @@ function islandora_entities_settings($form, &$form_state) {
     '#required' => TRUE,
   );
 
+  $form['islandora_entities_scholar_only'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('List only Citation and Thesis objects on Person pages.'),
+    '#default_value' => variable_get('islandora_entities_scholar_only', TRUE),
+    '#description' => t('If checked, only Citation and Thesis objects from the Person will be listed.
+      If unchecked, objects of all content models will be available.'),
+  );
+
   $form['islandora_entities_citation_base_query'] = array(
     '#type' => 'textarea',
     '#title' => t('Solr base query for citations.'),
@@ -172,18 +180,18 @@ function islandora_entities_settings($form, &$form_state) {
       'islandora_entities_citation_number',
       '20'
     ),
-    '#description' => t('Number of Citations to show under Recent Citations/Citations Tab'),
+    '#description' => t('Number of authored objects to display.'),
     '#required' => TRUE,
   );
 
   $form['islandora_entities_citation_author_solr_field'] = array(
     '#type' => 'textfield',
-    '#title' => t('Solr field for author of citations and theses.'),
+    '#title' => t('Solr field for the author.'),
     '#default_value' => variable_get(
       'islandora_entities_citation_author_solr_field',
       'mods_name_personal_displayForm_mt'
     ),
-    '#description' => t('Solr field to display as author under the Citation and Theses tabs.'),
+    '#description' => t('Solr field to display as author under the Citation and Theses  or Works tabs.'),
     '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
     '#required' => TRUE,
   );

--- a/includes/citation_tab.inc
+++ b/includes/citation_tab.inc
@@ -20,7 +20,7 @@
  * @return array
  *   The Drupal form.
  */
-function islandora_entities_citation_form($form, $form_state, $object, $type = 'theses') {
+function islandora_entities_citation_form($form, $form_state, $object, $type = NULL) {
   module_load_include('inc', 'islandora_entities', 'includes/utilities');
   if (module_exists('citation_exporter')) {
     if (CitationExporter::ReadyToExport()) {
@@ -44,7 +44,12 @@ function islandora_entities_citation_form($form, $form_state, $object, $type = '
       // PHP 5.3 and 5.4 can't handle empty((string) $identifier).
       $string_id = (string) $identifier;
       if ($identifier['type'] == 'u1' && !empty($string_id)) {
-        $results = islandora_entities_get_related_pids($string_id, (string) $simplexml->authority->titleInfo->title, $type);
+        if (isset($type)) {
+          $results = islandora_entities_get_related_pids($string_id, (string) $simplexml->authority->titleInfo->title, $type);
+        }
+        else {
+          $results = islandora_entities_get_related_pids($string_id, (string) $simplexml->authority->titleInfo->title);
+        }
       }
     }
     $lines = array();

--- a/includes/entities_rss.inc
+++ b/includes/entities_rss.inc
@@ -16,13 +16,19 @@ function islandora_entities_rss($pid) {
   drupal_add_http_header('Content-Type', 'application/rss+xml; charset=utf-8');
   $object = islandora_object_load($pid);
   $results = "";
+  $scholar_only = variable_get('islandora_entities_scholar_only', TRUE);
   if ($object['MADS']) {
     $mads = $object['MADS']->content;
     $simplexml = simplexml_load_string($mads);
     $identifiers = $simplexml->identifier;
     foreach ($identifiers as $identifier) {
       if ($identifier['type'] == 'u1') {
-        $results = islandora_entities_get_rss_related((string) $identifier, 'citations');
+        if ($scholar_only == TRUE) {
+          $results = islandora_entities_get_rss_related((string) $identifier, 'citations');
+        }
+        else {
+          $results = islandora_entities_get_rss_related((string) $identifier);
+        }
       }
     }
   }
@@ -60,16 +66,23 @@ function islandora_entities_rss($pid) {
 function islandora_entities_get_rss_related($identifier, $type) {
   module_load_include('inc', 'islandora_solr', 'includes/query_processor');
   global $base_url;
-  $mappings = array(
-    'citations' => 'ir:citationCModel',
-    'theses' => 'ir:thesisCModel',
-  );
-  $content_model = $mappings[$type];
+  $scholar_only = variable_get('islandora_entities_scholar_only', TRUE);
+  if ($scholar_only == TRUE) {
+    $mappings = array(
+      'citations' => 'ir:citationCModel',
+      'theses' => 'ir:thesisCModel',
+    );
+    $content_model = $mappings[$type];
+  }
   $entities_linking_field = variable_get(
       'islandora_entities_linking_content_solr_field', 'mods_name_personal_displayForm_mt'
   );
-  $query = "RELS_EXT_hasModel_uri_mt:\"$content_model\" AND {$entities_linking_field}:\"($identifier)\"";
-
+  if (isset($content_model)) {
+    $query = "RELS_EXT_hasModel_uri_mt:\"$content_model\" AND {$entities_linking_field}:\"($identifier)\"";
+  }
+  else {
+    $query = "{$entities_linking_field}:\"($identifier)\"";
+  }
   $qp = new IslandoraSolrQueryProcessor();
   $qp->buildQuery($query);
   $qp->solrParams['fl'] = "dc.description, dc.title, PID";

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -112,6 +112,22 @@ function islandora_entities_create_citation_tab(AbstractObject $object) {
   }
 }
 
+function islandora_entities_create_works_tab(AbstractObject $object) {
+  module_load_include('inc', 'islandora_entities', 'includes/utilities');
+  if ($object['MADS']) {
+    $mads = $object['MADS']->content;
+    $simplexml = simplexml_load_string($mads);
+    $identifiers = $simplexml->identifier;
+    foreach ($identifiers as $identifier) {
+      // PHP 5.3 and 5.4 can't handle empty((string) $identifier).
+      $string_id = (string) $identifier;
+      if ($identifier['type'] == 'u1' && !empty($string_id)) {
+        return islandora_entities_get_related($string_id, (string) $simplexml->authority->titleInfo->title, 'works');
+      }
+    }
+  }
+}
+
 /**
  * Gets all citations related to scholars's unique identifier.
  *
@@ -121,19 +137,27 @@ function islandora_entities_create_citation_tab(AbstractObject $object) {
  * @return array
  *   Array of links pointing to citations
  */
-function islandora_entities_get_related($identifier, $title, $type) {
-  $base_query = array(
-    'citations' => variable_get(
-      'islandora_entities_citation_base_query',
-      '+RELS_EXT_hasModel_uri_mt:"ir:citationCModel"'),
-    'theses' => variable_get(
-      'islandora_entities_thesis_base_query',
-      '+RELS_EXT_hasModel_uri_mt:"ir:thesisCModel"'),
-  );
+function islandora_entities_get_related($identifier, $title, $type = NULL) {
+  $scholar_only = variable_get('islandora_entities_scholar_only', TRUE);
+  if ($scholar_only == TRUE) {
+    $base_query = array(
+      'citations' => variable_get(
+        'islandora_entities_citation_base_query',
+        '+RELS_EXT_hasModel_uri_mt:"ir:citationCModel"'),
+      'theses' => variable_get(
+        'islandora_entities_thesis_base_query',
+        '+RELS_EXT_hasModel_uri_mt:"ir:thesisCModel"'),
+    );
+  }
   $entities_linking_field = variable_get(
       'islandora_entities_linking_content_solr_field', 'mods_name_personal_displayForm_mt'
   );
-  $query = "+{$entities_linking_field}:\"($identifier)\" AND {$base_query[$type]}";
+  if (isset($base_query)) {
+    $query = "+{$entities_linking_field}:\"($identifier)\" AND {$base_query[$type]}";
+  }
+  else {
+    $query = "+{$entities_linking_field}:\"($identifier)\"";
+  }
   $params = array(
     'limit' => variable_get('islandora_entities_citation_number', '20'),
   );

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -111,7 +111,7 @@ function islandora_entities_create_citation_tab(AbstractObject $object) {
     }
   }
 }
-
+/*
 function islandora_entities_create_works_tab(AbstractObject $object) {
   module_load_include('inc', 'islandora_entities', 'includes/utilities');
   if ($object['MADS']) {
@@ -127,7 +127,7 @@ function islandora_entities_create_works_tab(AbstractObject $object) {
     }
   }
 }
-
+*/
 /**
  * Gets all citations related to scholars's unique identifier.
  *
@@ -232,23 +232,30 @@ function islandora_entities_create_theses_tab(AbstractObject $object) {
  * @return array
  *   Array of links pointing to citations
  */
-function islandora_entities_get_related_pids($identifier, $title, $type) {
-  $base_query = array(
-    'citations' => variable_get(
-      'islandora_entities_citation_base_query',
-      '+RELS_EXT_hasModel_uri_mt:"ir:citationCModel"'),
-    'theses' => variable_get(
-      'islandora_entities_thesis_base_query',
-      '+RELS_EXT_hasModel_uri_mt:"ir:thesisCModel"'),
-  );
+function islandora_entities_get_related_pids($identifier, $title, $type = NULL) {
+  $scholar_only = variable_get('islandora_entities_scholar_only', TRUE);
+  if ($scholar_only == TRUE) {
+    $base_query = array(
+      'citations' => variable_get(
+        'islandora_entities_citation_base_query',
+        '+RELS_EXT_hasModel_uri_mt:"ir:citationCModel"'),
+      'theses' => variable_get(
+        'islandora_entities_thesis_base_query',
+        '+RELS_EXT_hasModel_uri_mt:"ir:thesisCModel"'),
+    );
+  }
   $entities_linking_field = variable_get(
       'islandora_entities_linking_content_solr_field', 'mods_name_personal_displayForm_mt'
   );
   $author_field = variable_get(
       'islandora_entities_citation_author_solr_field', 'mods_name_personal_displayForm_mt'
   );
-  $query = "+{$entities_linking_field}:\"($identifier)\" AND {$base_query[$type]}";
-
+  if (isset($base_query)) {
+    $query = "+{$entities_linking_field}:\"($identifier)\" AND {$base_query[$type]}";
+  }
+  else {
+    $query = "+{$entities_linking_field}:\"($identifier)\"";
+  }
   $params = array(
     'limit' => variable_get('islandora_entities_citation_number', '20'),
   );

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -111,23 +111,7 @@ function islandora_entities_create_citation_tab(AbstractObject $object) {
     }
   }
 }
-/*
-function islandora_entities_create_works_tab(AbstractObject $object) {
-  module_load_include('inc', 'islandora_entities', 'includes/utilities');
-  if ($object['MADS']) {
-    $mads = $object['MADS']->content;
-    $simplexml = simplexml_load_string($mads);
-    $identifiers = $simplexml->identifier;
-    foreach ($identifiers as $identifier) {
-      // PHP 5.3 and 5.4 can't handle empty((string) $identifier).
-      $string_id = (string) $identifier;
-      if ($identifier['type'] == 'u1' && !empty($string_id)) {
-        return islandora_entities_get_related($string_id, (string) $simplexml->authority->titleInfo->title, 'works');
-      }
-    }
-  }
-}
-*/
+
 /**
  * Gets all citations related to scholars's unique identifier.
  *

--- a/islandora_entities.module
+++ b/islandora_entities.module
@@ -111,6 +111,16 @@ function islandora_entities_menu() {
       'file' => 'includes/citation_tab.inc',
       'weight' => 2,
     ),
+    'islandora/object/%islandora_object/works' => array(
+      'title' => 'All Works',
+      'type' => MENU_LOCAL_TASK,
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('islandora_entities_citation_form', 2),
+      'access callback' => 'islandora_entities_citation_access',
+      'access arguments' => array(2),
+      'file' => 'includes/citation_tab.inc',
+      'weight' => 2,
+    ),
   );
 }
 
@@ -606,7 +616,7 @@ function islandora_entities_islandora_organizationCModel_islandora_view_object($
 /**
  * Access callback for citations tab.
  */
-function islandora_entities_citation_access($object, $type) {
+function islandora_entities_citation_access($object, $type = NULL) {
   module_load_include('inc', 'islandora_entities', 'includes/utilities');
   if (in_array('islandora:personCModel', $object->models)) {
     if ($object['MADS']) {
@@ -617,7 +627,12 @@ function islandora_entities_citation_access($object, $type) {
         // PHP 5.3 and 5.4 can't handle empty((string) $identifier).
         $string_id = (string) $identifier;
         if ($identifier['type'] == 'u1' && !empty($string_id)) {
-          $results = islandora_entities_get_related($string_id, (string) $simplexml->authority->titleInfo->title, $type);
+          if (isset($type)) {
+            $results = islandora_entities_get_related($string_id, (string) $simplexml->authority->titleInfo->title, $type);
+          }
+          else {
+            $results = islandora_entities_get_related($string_id, (string) $simplexml->authority->titleInfo->title);
+          }
         }
       }
     }


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-1638)

# What does this Pull Request do?

Allows objects of all CModels to be present on a Person object page - optionally.

# What's new?

Creates a new All Works tab that lists all objects regardless of CModel associated with the Person, and lists everything under Recent Citations. Provides a toggle to turn this on or off; defaults to the status quo of Scholarly objects only.

# How should this be tested?

* Create a Person
* Create a Citation and Thesis associated with that person (including their identifier as appropriate)
* Create a Large Image object with the same metadata in the Name field (including the Person's identifier)
* View the Person; only their Citation and Thesis should be displayed
* Un-check the Scholar Only checkbox in the config form
* View again; all their works should appear under Recent Citations, and a new All Works tab should appear

# Additional Notes:

I'm currently getting a Solr error notice when the Scholar Only box is checked; would appreciate some help diagnosing that.

# Interested parties
@rosiel @Islandora/7-x-1-x-committers
