### PR TITLE
In PHP 7 applying the empty index operator on a string throws a fatal…

### DIFF
--- a/includes/citation_tab.inc
+++ b/includes/citation_tab.inc
@@ -80,7 +80,7 @@ function islandora_entities_citation_form($form, $form_state, $object, $type = '
     '#title' => t('Citations'),
     '#header' => $header,
     '#options' => $lines,
-    '#attributes' => '',
+    '#attributes' => array(),
     '#empty' => t("There are no @type.", array('@type' => $type)),
   );
   if ($has_entries) {


### PR DESCRIPTION
**ISLANDORA-2507**: (https://jira.lyrasis.org/browse/ISLANDORA-2507)

# What does this Pull Request do?
This pull request changes the empty string assignment of the citation's #attributes to an empty array.

# How should this be tested?
In a PHP ^7.10 environment:
* Create a person entity object with an identifier
* Create a citation object, ensure you assign the Qualified Name as the identifier of the person object created.
* Navigate to the person object and click on the Citations tab
* This should result in a fatal PHP error.

> TypeError: Argument 1 passed to drupal_attributes() must be of the type array, string given, called in /var/www/drupal7/includes/form.inc on line 3236 in drupal_attributes() (line 2459 of /var/www/drupal7/includes/common.inc).

# Interested parties
@Islandora/7-x-1-x-committers
@dannylamb 
